### PR TITLE
Move isAuthorized to GrantHandler interface

### DIFF
--- a/components/auth/org.wso2.carbon.auth.client.registration.rest.api/src/main/java/org/wso2/carbon/auth/client/registration/rest/api/utils/MappingUtil.java
+++ b/components/auth/org.wso2.carbon.auth.client.registration.rest.api/src/main/java/org/wso2/carbon/auth/client/registration/rest/api/utils/MappingUtil.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.auth.client.registration.rest.api.utils;
 
 import org.apache.commons.lang3.StringUtils;
-import org.wso2.carbon.auth.client.registration.constants.ClientRegistrationConstants;
+import org.wso2.carbon.auth.client.registration.Constants;
 import org.wso2.carbon.auth.client.registration.model.Application;
 import org.wso2.carbon.auth.client.registration.rest.api.dto.ApplicationDTO;
 import org.wso2.carbon.auth.client.registration.rest.api.dto.RegistrationRequestDTO;
@@ -59,7 +59,7 @@ public class MappingUtil {
         if (StringUtils.isEmpty(callbackurl)) {
             return null;
         }
-        if (!callbackurl.startsWith(ClientRegistrationConstants.CALLBACK_URL_REGEXP_PREFIX)) {
+        if (!callbackurl.startsWith(Constants.CALLBACK_URL_REGEXP_PREFIX)) {
             return Arrays.asList(callbackurl);
         }
         String urls = callbackurl.substring(callbackurl.indexOf('(') + 1, callbackurl.indexOf(')'));
@@ -107,8 +107,8 @@ public class MappingUtil {
         //TODO: After implement multi-urls to the oAuth application, we have to change this API call
         //TODO: need to validate before processing request
         if (redirectUris.size() == 0) {
-            if ((grantTypes.contains(ClientRegistrationConstants.GrantTypes.AUTHORIZATION_CODE) || grantTypes.
-                    contains(ClientRegistrationConstants.GrantTypes.IMPLICIT))) {
+            if ((grantTypes.contains("authorization_code") || grantTypes.
+                    contains("implicit"))) {
                 throw new IllegalStateException("Valid input has not been provided");
             } else {
                 return null;
@@ -122,7 +122,7 @@ public class MappingUtil {
             }
 
         } else {
-            return ClientRegistrationConstants.CALLBACK_URL_REGEXP_PREFIX + createRegexPattern(redirectUris);
+            return "regexp=" + createRegexPattern(redirectUris);
         }
     }
 

--- a/components/auth/org.wso2.carbon.auth.client.registration/src/main/java/org/wso2/carbon/auth/client/registration/Constants.java
+++ b/components/auth/org.wso2.carbon.auth.client.registration/src/main/java/org/wso2/carbon/auth/client/registration/Constants.java
@@ -18,12 +18,12 @@
  *
  */
 
-package org.wso2.carbon.auth.client.registration.constants;
+package org.wso2.carbon.auth.client.registration;
 
 /**
  * This class holds the constants used by DynamicClientRegistration component.
  */
-public class ClientRegistrationConstants {
+public class Constants {
 
     public static final String CALLBACK_URL_REGEXP_PREFIX = "regexp=";
 

--- a/components/auth/org.wso2.carbon.auth.oauth/src/main/java/org/wso2/carbon/auth/oauth/GrantHandler.java
+++ b/components/auth/org.wso2.carbon.auth.oauth/src/main/java/org/wso2/carbon/auth/oauth/GrantHandler.java
@@ -20,6 +20,8 @@
 
 package org.wso2.carbon.auth.oauth;
 
+import org.apache.commons.lang3.StringUtils;
+import org.wso2.carbon.auth.client.registration.model.Application;
 import org.wso2.carbon.auth.oauth.dto.AccessTokenContext;
 import org.wso2.carbon.auth.oauth.exception.OAuthDAOException;
 
@@ -37,4 +39,11 @@ public interface GrantHandler {
      */
     void process(String authorization, AccessTokenContext context, Map<String, String> queryParameters)
             throws OAuthDAOException;
+
+    default boolean isAuthorizedClient(Application application, String grantType) {
+        if (application == null || StringUtils.isEmpty(application.getGrantTypes())) {
+            return false;
+        }
+        return application.getGrantTypes().contains(grantType);
+    }
 }


### PR DESCRIPTION
In this PR:

- Moved `isAuthorizedClient` method to `GrantHandler` interface as a default method, from `RefreshGrantHandler` since this method is more generic to all types of handlers
- Moved `org.wso2.carbon.auth.client.registration` Constance class to its root src directory.